### PR TITLE
Expand fallback country list

### DIFF
--- a/countries-fallback.json
+++ b/countries-fallback.json
@@ -34,5 +34,23 @@
     "name": {"common": "Australia"},
     "flags": {"png": "https://flagcdn.com/w320/au.png"},
     "timezones": ["UTC+10:00"]
+  },
+  {
+    "cca2": "AE",
+    "name": {"common": "United Arab Emirates"},
+    "flags": {"png": "https://flagcdn.com/w320/ae.png"},
+    "timezones": ["UTC+04:00"]
+  },
+  {
+    "cca2": "JE",
+    "name": {"common": "Jersey"},
+    "flags": {"png": "https://flagcdn.com/w320/je.png"},
+    "timezones": ["UTC+00:00"]
+  },
+  {
+    "cca2": "GG",
+    "name": {"common": "Guernsey"},
+    "flags": {"png": "https://flagcdn.com/w320/gg.png"},
+    "timezones": ["UTC+00:00"]
   }
 ]

--- a/iana-zones.json
+++ b/iana-zones.json
@@ -1,6 +1,8 @@
 {
   "US": "America/New_York",
   "GB": "Europe/London",
+  "JE": "Europe/Jersey",
+  "GG": "Europe/Guernsey",
   "FR": "Europe/Paris",
   "DE": "Europe/Berlin",
   "ES": "Europe/Madrid",

--- a/script.js
+++ b/script.js
@@ -368,7 +368,7 @@ function renderCountryList(countries) {
     let newTZ;
     if (ianaZoneMap[country.cca2]) {
       newTZ = ianaZoneMap[country.cca2];
-    } else if (country.cca2 === "JE") {
+    } else if (country.cca2 === "JE" || country.cca2 === "GG") {
       newTZ = "Europe/London";
     } else if (country.timezones && country.timezones.length > 0) {
       newTZ = convertUTCOffsetToIANA(country.timezones[0]);


### PR DESCRIPTION
## Summary
- include United Arab Emirates, Jersey, and Guernsey in `countries-fallback.json`
- add IANA zone mappings for Jersey and Guernsey
- fall back to London time zone for JE and GG

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd815314c832788ce828e9ac8bb5e