### PR TITLE
Add version tracker modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="styles.css"/>
 </head>
 <body>
+  <a id="versionLink" href="#">See what's new</a>
   <!-- Top Right Controls (No hour toggle here) -->
   <div id="topControls">
     <button id="scheduleButton" class="schedule-button">Schedule</button>
@@ -80,6 +81,15 @@
           Toggle Hours: <span id="hoursToggleText">24h</span>
         </button>
       </div>
+    </div>
+  </div>
+
+  <!-- Version Modal -->
+  <div id="versionModal" class="modal">
+    <div class="modal-content">
+      <span id="closeVersion" class="close">&times;</span>
+      <h2>Version History</h2>
+      <div id="versionList"></div>
     </div>
   </div>
   

--- a/script.js
+++ b/script.js
@@ -300,6 +300,12 @@ const settingsButton = document.getElementById("settingsButton");
 const settingsModal = document.getElementById("settingsModal");
 const closeSettings = document.getElementById("closeSettings");
 
+// ---------- Version Modal Functionality ----------
+const versionLink = document.getElementById("versionLink");
+const versionModal = document.getElementById("versionModal");
+const closeVersion = document.getElementById("closeVersion");
+const versionList = document.getElementById("versionList");
+
 settingsButton.addEventListener("click", () => {
   document.getElementById("hoursToggleText").innerText = use24Hour ? "24h" : "12h";
   settingsModal.style.display = "flex";
@@ -307,6 +313,40 @@ settingsButton.addEventListener("click", () => {
 
 closeSettings.addEventListener("click", () => {
   settingsModal.style.display = "none";
+});
+
+versionLink.addEventListener("click", (e) => {
+  e.preventDefault();
+  fetch("versions.json")
+    .then(r => r.json())
+    .then(data => {
+      versionList.innerHTML = "";
+      data.forEach(entry => {
+        const div = document.createElement("div");
+        if (typeof entry === "string") {
+          div.textContent = entry;
+        } else {
+          const parts = [];
+          if (entry.version) parts.push(entry.version);
+          if (entry.date) parts.push(entry.date);
+          if (entry.description) parts.push(entry.description);
+          div.textContent = parts.join(" - ");
+        }
+        versionList.appendChild(div);
+      });
+      versionModal.style.display = "flex";
+    })
+    .catch(err => console.error("Error loading versions:", err));
+});
+
+closeVersion.addEventListener("click", () => {
+  versionModal.style.display = "none";
+});
+
+window.addEventListener("click", (event) => {
+  if (event.target === versionModal) {
+    versionModal.style.display = "none";
+  }
 });
 
 // Background previews

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,16 @@ body {
   gap: 0.5rem;
 }
 
+#versionLink {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  color: white;
+  text-decoration: underline;
+  cursor: pointer;
+  z-index: 20;
+}
+
 /* Global Toggle Button */
 .global-toggle {
   padding: 0.5rem 1rem;
@@ -445,6 +455,13 @@ button {
   flex-grow: 1;
   overflow-y: auto;
   padding-right: 10px;
+}
+
+#versionList {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .country-item {

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,3 @@
+[
+  {"version": "1.0.0", "description": "Initial release"}
+]


### PR DESCRIPTION
## Summary
- add a top-left link to open version history
- create version history modal and stylesheet rules
- load version data from new `versions.json`
- fetch and display versions on demand

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddff8013083279882096cbe45fae7