### PR TITLE
Improve version history ordering and styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -321,7 +321,7 @@ versionLink.addEventListener("click", (e) => {
     .then(r => r.json())
     .then(data => {
       versionList.innerHTML = "";
-      data.forEach(entry => {
+      data.slice().reverse().forEach(entry => {
         const container = document.createElement("div");
         container.className = "version-entry";
 

--- a/styles.css
+++ b/styles.css
@@ -462,10 +462,14 @@ button {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .version-entry {
   line-height: 1.4;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #e0e0e0;
 }
 
 .country-item {


### PR DESCRIPTION
## Summary
- show latest versions first
- style the version history list with separators
- make the list scrollable when it grows

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de48ba8888327849f028885ebddfb