### PR TITLE
Revamp settings background grid and clarify hour format

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,23 +62,19 @@
       <h2>Settings</h2>
       <div class="settings-section">
         <h3>Background</h3>
-        <div class="background-slider">
-          <button id="bgPrev" class="slide-btn">&#9664;</button>
-          <div id="backgroundOptions" class="background-options">
-            <img class="bg-preview" data-bg="Images/background1.jpg" src="Images/background1.jpg" alt="Background 1">
-            <img class="bg-preview" data-bg="Images/background2.jpg" src="Images/background2.jpg" alt="Background 2">
-            <img class="bg-preview" data-bg="Images/background3.jpg" src="Images/background3.jpg" alt="Background 3">
-            <img class="bg-preview" data-bg="Images/background4.jpg" src="Images/background4.jpg" alt="Background 4">
-            <img class="bg-preview" data-bg="Images/background5.jpg" src="Images/background5.jpg" alt="Background 5">
-            <img class="bg-preview" data-bg="Images/background6.jpg" src="Images/background6.jpg" alt="Background 6">
-          </div>
-          <button id="bgNext" class="slide-btn">&#9654;</button>
+        <div id="backgroundGrid" class="background-grid">
+          <img class="bg-preview" data-bg="Images/background1.jpg" src="Images/background1.jpg" alt="Background 1">
+          <img class="bg-preview" data-bg="Images/background2.jpg" src="Images/background2.jpg" alt="Background 2">
+          <img class="bg-preview" data-bg="Images/background3.jpg" src="Images/background3.jpg" alt="Background 3">
+          <img class="bg-preview" data-bg="Images/background4.jpg" src="Images/background4.jpg" alt="Background 4">
+          <img class="bg-preview" data-bg="Images/background5.jpg" src="Images/background5.jpg" alt="Background 5">
+          <img class="bg-preview" data-bg="Images/background6.jpg" src="Images/background6.jpg" alt="Background 6">
         </div>
       </div>
       <div class="settings-section">
-        <h3>Hours Format</h3>
+        <h3>Clock Format</h3>
         <button id="hoursToggleBtn" class="global-toggle">
-          Toggle Hours: <span id="hoursToggleText">24h</span>
+          Format: <span id="hoursToggleText">24-hour</span>
         </button>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -307,7 +307,7 @@ const closeVersion = document.getElementById("closeVersion");
 const versionList = document.getElementById("versionList");
 
 settingsButton.addEventListener("click", () => {
-  document.getElementById("hoursToggleText").innerText = use24Hour ? "24h" : "12h";
+  document.getElementById("hoursToggleText").innerText = use24Hour ? "24-hour" : "12-hour";
   settingsModal.style.display = "flex";
 });
 
@@ -364,9 +364,6 @@ window.addEventListener("click", (event) => {
 
 // Background previews
 const bgPreviews = document.querySelectorAll(".bg-preview");
-const bgContainer = document.getElementById("backgroundOptions");
-const bgPrevBtn = document.getElementById("bgPrev");
-const bgNextBtn = document.getElementById("bgNext");
 bgPreviews.forEach(preview => {
   preview.addEventListener("click", () => {
     const newBg = preview.getAttribute("data-bg");
@@ -376,19 +373,11 @@ bgPreviews.forEach(preview => {
   });
 });
 
-bgPrevBtn.addEventListener("click", () => {
-  bgContainer.scrollBy({ left: -100, behavior: "smooth" });
-});
-
-bgNextBtn.addEventListener("click", () => {
-  bgContainer.scrollBy({ left: 100, behavior: "smooth" });
-});
-
 // Hours toggle in settings
 const hoursToggleBtn = document.getElementById("hoursToggleBtn");
 hoursToggleBtn.addEventListener("click", () => {
   use24Hour = !use24Hour;
-  document.getElementById("hoursToggleText").innerText = use24Hour ? "24h" : "12h";
+  document.getElementById("hoursToggleText").innerText = use24Hour ? "24-hour" : "12-hour";
   localStorage.setItem("use24Hour", use24Hour);
 });
 

--- a/styles.css
+++ b/styles.css
@@ -291,38 +291,23 @@ button {
 }
 
 /* Settings Modal Specific Styling */
-.background-slider {
-  display: flex;
-  align-items: center;
+.background-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 0.5rem;
 }
 
-.background-options {
-  display: flex;
-  overflow-x: auto;
-  gap: 0.5rem;
-  scroll-snap-type: x mandatory;
-}
-.background-options .bg-preview {
-  width: 80px;
+.background-grid .bg-preview {
+  width: 100%;
   height: 60px;
   object-fit: cover;
   border: 2px solid transparent;
   cursor: pointer;
   border-radius: 0.5rem;
-  scroll-snap-align: center;
-  flex: 0 0 auto;
   transition: border 0.2s;
 }
-.background-options .bg-preview:hover {
+.background-grid .bg-preview:hover {
   border: 2px solid #007BFF;
-}
-
-.slide-btn {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
 }
 
 /* Updated Add Widget Button (cssbuttons-io style) */


### PR DESCRIPTION
## Summary
- revamp Settings modal background section with a 3x2 grid instead of sliders
- clarify hour format toggle text as `24-hour`/`12-hour`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de857af6c8327b76aec4fae1ffcfe