### PR TITLE
Add monochrome theme and widget transparency options

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,15 +61,12 @@
       <span id="closeSettings" class="close">&times;</span>
       <h2>Settings</h2>
       <div class="settings-section">
-        <h3>Background</h3>
-        <div id="backgroundGrid" class="background-grid">
-          <img class="bg-preview" data-bg="Images/background1.jpg" src="Images/background1.jpg" alt="Background 1">
-          <img class="bg-preview" data-bg="Images/background2.jpg" src="Images/background2.jpg" alt="Background 2">
-          <img class="bg-preview" data-bg="Images/background3.jpg" src="Images/background3.jpg" alt="Background 3">
-          <img class="bg-preview" data-bg="Images/background4.jpg" src="Images/background4.jpg" alt="Background 4">
-          <img class="bg-preview" data-bg="Images/background5.jpg" src="Images/background5.jpg" alt="Background 5">
-          <img class="bg-preview" data-bg="Images/background6.jpg" src="Images/background6.jpg" alt="Background 6">
-        </div>
+        <h3>Theme</h3>
+        <button id="themeToggleBtn" class="global-toggle">System</button>
+      </div>
+      <div class="settings-section">
+        <h3>Transparent Widgets</h3>
+        <button id="transparentToggleBtn" class="global-toggle">Off</button>
       </div>
       <div class="settings-section">
         <h3>Clock Format</h3>

--- a/script.js
+++ b/script.js
@@ -6,12 +6,15 @@ let selectedWidgetIndex = null;
 let schedulingMode = false;
 let scheduledTime = null;
 let ianaZoneMap = {};
+let theme = 'system';
+let transparentWidgets = false;
 
 function loadSettings() {
   const storedMainWidget = localStorage.getItem('mainWidget');
   const storedGridWidgets = localStorage.getItem('gridWidgets');
-  const storedBackground = localStorage.getItem('backgroundImage');
   const storedHoursFormat = localStorage.getItem('use24Hour');
+  const storedTheme = localStorage.getItem('theme');
+  const storedTransparent = localStorage.getItem('transparentWidgets');
 
   // Load main widget
   mainWidget = storedMainWidget
@@ -54,10 +57,14 @@ function loadSettings() {
     use24Hour = (storedHoursFormat === "true");
   }
   
-  // Set background if stored
-  if (storedBackground) {
-    document.body.style.backgroundImage = `url(${storedBackground})`;
+  if (storedTheme) {
+    theme = storedTheme;
   }
+  if (storedTransparent !== null) {
+    transparentWidgets = (storedTransparent === 'true');
+  }
+  applyTheme();
+  applyTransparency();
 }
 
 // Save to local storage
@@ -65,31 +72,18 @@ function saveSettings() {
   localStorage.setItem('mainWidget', JSON.stringify(mainWidget));
   localStorage.setItem('gridWidgets', JSON.stringify(gridWidgets));
   localStorage.setItem('use24Hour', use24Hour);
+  localStorage.setItem('theme', theme);
+  localStorage.setItem('transparentWidgets', transparentWidgets);
 }
 
 // ---------- Update Widget Styles Based on Background ----------
-function updateWidgetStyles(bgUrl) {
-  // All "widget" elements (main + bottom)
-  const widgets = document.querySelectorAll(".widget");
-  widgets.forEach(widget => {
-    widget.classList.remove("blur-widget", "dark-widget", "blur-dark");
-  });
-  // If background2 => dark
-  if (bgUrl.includes("background2.jpg")) {
-    widgets.forEach(widget => widget.classList.add("dark-widget"));
-  }
-  // If background4 or background5 => blur + white text
-  else if (bgUrl.includes("background4.jpg") || bgUrl.includes("background5.jpg")) {
-    widgets.forEach(widget => {
-      widget.classList.add("blur-widget");
-      widget.classList.add("blur-dark");
-    });
-  }
-  // If background3 or background6 => blur only
-  else if (bgUrl.includes("background3.jpg") || bgUrl.includes("background6.jpg")) {
-    widgets.forEach(widget => widget.classList.add("blur-widget"));
-  }
-  // background1 => no extra style
+function applyTheme() {
+  document.body.classList.toggle('theme-bw', theme === 'bw');
+  document.body.classList.toggle('theme-system', theme === 'system');
+}
+
+function applyTransparency() {
+  document.body.classList.toggle('transparent-widgets', transparentWidgets);
 }
 
 function getTimezoneOffset(timeZone, refTime) {
@@ -289,10 +283,8 @@ function renderGrid() {
     gridContainer.appendChild(addItem);
   }
 
-  const storedBg = localStorage.getItem("backgroundImage");
-  if (storedBg) {
-    updateWidgetStyles(storedBg);
-  }
+  applyTransparency();
+  applyTheme();
 }
 
 // ---------- Settings Modal Functionality ----------
@@ -308,6 +300,8 @@ const versionList = document.getElementById("versionList");
 
 settingsButton.addEventListener("click", () => {
   document.getElementById("hoursToggleText").innerText = use24Hour ? "24-hour" : "12-hour";
+  document.getElementById("themeToggleBtn").innerText = theme === 'bw' ? 'Black & White' : 'System';
+  document.getElementById("transparentToggleBtn").innerText = transparentWidgets ? 'On' : 'Off';
   settingsModal.style.display = "flex";
 });
 
@@ -362,16 +356,6 @@ window.addEventListener("click", (event) => {
   }
 });
 
-// Background previews
-const bgPreviews = document.querySelectorAll(".bg-preview");
-bgPreviews.forEach(preview => {
-  preview.addEventListener("click", () => {
-    const newBg = preview.getAttribute("data-bg");
-    document.body.style.backgroundImage = `url(${newBg})`;
-    localStorage.setItem("backgroundImage", newBg);
-    updateWidgetStyles(newBg);
-  });
-});
 
 // Hours toggle in settings
 const hoursToggleBtn = document.getElementById("hoursToggleBtn");
@@ -379,6 +363,22 @@ hoursToggleBtn.addEventListener("click", () => {
   use24Hour = !use24Hour;
   document.getElementById("hoursToggleText").innerText = use24Hour ? "24-hour" : "12-hour";
   localStorage.setItem("use24Hour", use24Hour);
+});
+
+const themeToggleBtn = document.getElementById('themeToggleBtn');
+themeToggleBtn.addEventListener('click', () => {
+  theme = theme === 'bw' ? 'system' : 'bw';
+  themeToggleBtn.innerText = theme === 'bw' ? 'Black & White' : 'System';
+  applyTheme();
+  saveSettings();
+});
+
+const transparentToggleBtn = document.getElementById('transparentToggleBtn');
+transparentToggleBtn.addEventListener('click', () => {
+  transparentWidgets = !transparentWidgets;
+  transparentToggleBtn.innerText = transparentWidgets ? 'On' : 'Off';
+  applyTransparency();
+  saveSettings();
 });
 
 // ---------- Country Selection ----------
@@ -554,12 +554,6 @@ document.addEventListener("fullscreenchange", () => {
 loadSettings();
 renderGrid();
 updateMainWidgetDisplay();
-
-// Re-apply blur/dark styling after grid is rendered
-const storedBg = localStorage.getItem("backgroundImage");
-if (storedBg) {
-  updateWidgetStyles(storedBg);
-}
 updateAllTimes();
 
 

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,41 @@ body {
   background-position: center;
 }
 
+body.theme-bw {
+  background: #ffffff;
+  color: #000;
+}
+
+body.theme-bw .widget {
+  background: #fff;
+  color: #000;
+}
+
+body.theme-system {
+  color: #000;
+}
+
+body.theme-system .widget {
+  background: #fff;
+  color: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+  body.theme-system {
+    background: #000;
+    color: #fff;
+  }
+  body.theme-system .widget {
+    background: #333;
+    color: #fff;
+  }
+}
+
+.transparent-widgets .widget {
+  background: transparent;
+  box-shadow: none;
+}
+
 /* Top Right Controls */
 #topControls {
   position: fixed;
@@ -84,28 +119,6 @@ body {
   position: relative;
 }
 
-/* Transparent blur mode for backgrounds 3–6 */
-.blur-widget {
-  background: rgba(255, 255, 255, 0.6) !important;
-  backdrop-filter: blur(5px);
-}
-
-/* Additional class to force text white on blurred widgets (for backgrounds 4–5) */
-.blur-dark {
-  color: #fff !important;
-}
-.blur-dark * {
-  color: #fff !important;
-}
-
-/* Dark mode for background2 */
-.dark-widget {
-  background: rgba(51, 51, 51, 0.8) !important;
-  color: #fff !important;
-}
-.dark-widget * {
-  color: #fff !important;
-}
 
 /* Location element for main & grid widgets */
 .location {
@@ -290,25 +303,6 @@ button {
   appearance: none;
 }
 
-/* Settings Modal Specific Styling */
-.background-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
-}
-
-.background-grid .bg-preview {
-  width: 100%;
-  height: 60px;
-  object-fit: cover;
-  border: 2px solid transparent;
-  cursor: pointer;
-  border-radius: 0.5rem;
-  transition: border 0.2s;
-}
-.background-grid .bg-preview:hover {
-  border: 2px solid #007BFF;
-}
 
 /* Updated Add Widget Button (cssbuttons-io style) */
 .cssbuttons-io-button {


### PR DESCRIPTION
## Summary
- replace background image selection with theme and transparency options
- add theme handling and widget transparency toggles in JavaScript
- define new CSS classes for black & white and system themes and for transparent widgets
- drop old background related styles

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df7cc40e083278df6bad38f520208