### PR TITLE
Add theme toggle and transparent widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,15 +61,17 @@
       <span id="closeSettings" class="close">&times;</span>
       <h2>Settings</h2>
       <div class="settings-section">
-        <h3>Background</h3>
-        <div id="backgroundGrid" class="background-grid">
-          <img class="bg-preview" data-bg="Images/background1.jpg" src="Images/background1.jpg" alt="Background 1">
-          <img class="bg-preview" data-bg="Images/background2.jpg" src="Images/background2.jpg" alt="Background 2">
-          <img class="bg-preview" data-bg="Images/background3.jpg" src="Images/background3.jpg" alt="Background 3">
-          <img class="bg-preview" data-bg="Images/background4.jpg" src="Images/background4.jpg" alt="Background 4">
-          <img class="bg-preview" data-bg="Images/background5.jpg" src="Images/background5.jpg" alt="Background 5">
-          <img class="bg-preview" data-bg="Images/background6.jpg" src="Images/background6.jpg" alt="Background 6">
+        <h3>Theme</h3>
+        <div id="themeOptions" class="theme-options">
+          <label><input type="radio" name="theme" value="system"> System</label>
+          <label><input type="radio" name="theme" value="light"> White</label>
+          <label><input type="radio" name="theme" value="dark"> Black</label>
         </div>
+      </div>
+      <div class="settings-section">
+        <label>
+          <input type="checkbox" id="transparentWidgets"> Transparent widget backgrounds
+        </label>
       </div>
       <div class="settings-section">
         <h3>Clock Format</h3>

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,44 @@ body {
   background-position: center;
 }
 
+body.light-theme {
+  background-color: #ffffff;
+  color: #000;
+}
+
+body.dark-theme {
+  background-color: #000;
+  color: #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not(.light-theme):not(.dark-theme) {
+    background-color: #000;
+    color: #fff;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  body:not(.light-theme):not(.dark-theme) {
+    background-color: #fff;
+    color: #000;
+  }
+}
+
+.theme-options label {
+  margin-right: 1rem;
+}
+
+.transparent-widget {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+body.dark-theme .widget,
+body.dark-theme .widget * {
+  color: #fff;
+}
+
 /* Top Right Controls */
 #topControls {
   position: fixed;
@@ -290,25 +328,7 @@ button {
   appearance: none;
 }
 
-/* Settings Modal Specific Styling */
-.background-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
-}
 
-.background-grid .bg-preview {
-  width: 100%;
-  height: 60px;
-  object-fit: cover;
-  border: 2px solid transparent;
-  cursor: pointer;
-  border-radius: 0.5rem;
-  transition: border 0.2s;
-}
-.background-grid .bg-preview:hover {
-  border: 2px solid #007BFF;
-}
 
 /* Updated Add Widget Button (cssbuttons-io style) */
 .cssbuttons-io-button {


### PR DESCRIPTION
## Summary
- add radio options for selecting black/white/system themes
- allow transparent widget backgrounds via checkbox
- implement theme and transparency logic in JS
- add dark/light theme styles and system scheme defaults
- remove unused background image options

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df7cc40e083278df6bad38f520208