### PR TITLE
Fix text color on background 4

### DIFF
--- a/script.js
+++ b/script.js
@@ -78,15 +78,17 @@ function updateWidgetStyles(bgUrl) {
   if (bgUrl.includes("background2.jpg")) {
     widgets.forEach(widget => widget.classList.add("dark-widget"));
   }
-  // If background4 or background5 => blur + white text
-  else if (bgUrl.includes("background4.jpg") || bgUrl.includes("background5.jpg")) {
+  // If background5 => blur + white text
+  else if (bgUrl.includes("background5.jpg")) {
     widgets.forEach(widget => {
       widget.classList.add("blur-widget");
       widget.classList.add("blur-dark");
     });
   }
-  // If background3 or background6 => blur only
-  else if (bgUrl.includes("background3.jpg") || bgUrl.includes("background6.jpg")) {
+  // If background3, background4 or background6 => blur only
+  else if (bgUrl.includes("background3.jpg") ||
+           bgUrl.includes("background4.jpg") ||
+           bgUrl.includes("background6.jpg")) {
     widgets.forEach(widget => widget.classList.add("blur-widget"));
   }
   // background1 => no extra style

--- a/styles.css
+++ b/styles.css
@@ -90,7 +90,7 @@ body {
   backdrop-filter: blur(5px);
 }
 
-/* Additional class to force text white on blurred widgets (for backgrounds 4–5) */
+/* Additional class to force text white on blurred widgets (for background 5) */
 .blur-dark {
   color: #fff !important;
 }


### PR DESCRIPTION
## Summary
- adjust widget styling logic so background 4 uses dark text
- update comment in CSS for blur-dark class

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfd29fd2083279c2b4e99b9dd8ab7