### PR TITLE
Add emoji icons for widget actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,7 @@
       </div>
       <div class="widget-actions">
         <!-- Change Time Zone button -->
-        <button id="changeMainTimeZone" class="globe-button circle-button">
-          <span class="material-icons" style="font-size:32px;"></span>
-        </button>
+        <button id="changeMainTimeZone" class="globe-button circle-button">🌐</button>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -249,11 +249,10 @@ function renderGrid() {
     
     let actionsDiv = document.createElement("div");
     actionsDiv.className = "widget-actions";
-    actionsDiv.style.display = "flex";
-    actionsDiv.style.justifyContent = "space-between";
     
     let globeBtn = document.createElement("button");
     globeBtn.className = "globe-button circle-button";
+    globeBtn.textContent = "🌐";
     globeBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       selectedWidgetIndex = index;
@@ -267,6 +266,7 @@ function renderGrid() {
     // Trash button
     let trashBtn = document.createElement("button");
     trashBtn.className = "trash-button circle-button";
+    trashBtn.textContent = "🗑️";
     trashBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       gridWidgets.splice(index, 1);

--- a/styles.css
+++ b/styles.css
@@ -145,10 +145,9 @@ body {
 
 /* Widget actions */
 .widget-actions {
-  margin-top: 1rem;
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
+  position: relative;
+  margin: 0;
+  height: 0;
 }
 
 /* Buttons general */
@@ -175,6 +174,18 @@ button {
 /* Globe button (blue) */
 .globe-button {
   background-color: #007BFF;
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+}
+
+/* Position trash icon top-right */
+.trash-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background-color: #dc3545;
+  color: white;
 }
 
 /* Grid Container: EXACT 3x2 layout */
@@ -558,25 +569,6 @@ button {
   display: none;
 }
 
-/* Trash Button (unchanged) */
-.trash-button {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 1em;
-  border: 0px solid transparent;
-  background-color: rgba(100,77,237,0.08);
-  border-radius: 1.25em;
-  transition: all 0.2s linear;
-}
-.trash-button:hover {
-  box-shadow: 3.4px 2.5px 4.9px rgba(0, 0, 0, 0.025),
-    8.6px 6.3px 12.4px rgba(0, 0, 0, 0.035),
-    17.5px 12.8px 25.3px rgba(0, 0, 0, 0.045),
-    36.1px 26.3px 52.2px rgba(0, 0, 0, 0.055),
-    99px 72px 143px rgba(0, 0, 0, 0.08);
-}
 .tooltip {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
## Summary
- add globe emoji for changing timezone
- show trash emoji for deleting widgets
- reposition widget action buttons with CSS

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e03edad648327827dd63674625d84