### PR TITLE
Replace circular delete button with grey icon

### DIFF
--- a/script.js
+++ b/script.js
@@ -266,7 +266,12 @@ function renderGrid() {
     
     // Trash button
     let trashBtn = document.createElement("button");
-    trashBtn.className = "trash-button circle-button";
+    trashBtn.className = "trash-button";
+    trashBtn.innerHTML = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M20 6a1 1 0 0 1 .117 1.993l-.117 .007h-.081l-.919 11a3 3 0 0 1 -2.824 2.995l-.176 .005h-8c-1.598 0 -2.904 -1.249 -2.992 -2.75l-.005 -.167l-.923 -11.083h-.08a1 1 0 0 1 -.117 -1.993l.117 -.007h16z" />
+        <path d="M14 2a2 2 0 0 1 2 2a1 1 0 0 1 -1.993 .117l-.007 -.117h-4l-.007 .117a1 1 0 0 1 -1.993 -.117a2 2 0 0 1 1.85 -1.995l.15 -.005h4z" />
+      </svg>`;
     trashBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       gridWidgets.splice(index, 1);

--- a/styles.css
+++ b/styles.css
@@ -558,24 +558,23 @@ button {
   display: none;
 }
 
-/* Trash Button (unchanged) */
+/* Trash Button */
 .trash-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #808080;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
   align-items: center;
-  padding: 1em;
-  border: 0px solid transparent;
-  background-color: rgba(100,77,237,0.08);
-  border-radius: 1.25em;
-  transition: all 0.2s linear;
+  justify-content: center;
+  cursor: pointer;
+}
+.trash-button svg {
+  width: 24px;
+  height: 24px;
 }
 .trash-button:hover {
-  box-shadow: 3.4px 2.5px 4.9px rgba(0, 0, 0, 0.025),
-    8.6px 6.3px 12.4px rgba(0, 0, 0, 0.035),
-    17.5px 12.8px 25.3px rgba(0, 0, 0, 0.045),
-    36.1px 26.3px 52.2px rgba(0, 0, 0, 0.055),
-    99px 72px 143px rgba(0, 0, 0, 0.08);
+  color: #555;
 }
 .tooltip {
   position: relative;


### PR DESCRIPTION
## Summary
- redesign trash button style
- embed grey trash can SVG into delete button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed2d19be88327b407d141e22b7bc5